### PR TITLE
Fix invalid usage of pthread_mutex_init()

### DIFF
--- a/Cpp-C/Eta/Include/Util/rtr/rsslThread.h
+++ b/Cpp-C/Eta/Include/Util/rtr/rsslThread.h
@@ -84,7 +84,7 @@ RTR_C_INLINE int RSSL_MUTEX_INIT(RsslMutex *pMutex)
 	pthread_mutexattr_settype(&mutexAttr, PTHREAD_MUTEX_RECURSIVE);
 	return pthread_mutex_init(pMutex, &mutexAttr);
 }
-#define RSSL_MUTEX_INIT_ESDK(__pMutex) (pthread_mutex_init((__pMutex),(pthread_mutexattr_t *)PTHREAD_PROCESS_PRIVATE) ? RSSL_FALSE : RSSL_TRUE)
+#define RSSL_MUTEX_INIT_ESDK(__pMutex) (pthread_mutex_init((__pMutex), NULL) ? RSSL_FALSE : RSSL_TRUE)
 #define RSSL_MUTEX_DESTROY(__pMutex) (pthread_mutex_destroy(__pMutex))
 #define RSSL_MUTEX_LOCK(__pMutex) (pthread_mutex_lock(__pMutex)) 
 #define RSSL_MUTEX_UNLOCK(__pMutex) (pthread_mutex_unlock(__pMutex))


### PR DESCRIPTION
In the `RSSL_MUTEX_INIT_ESDK` macro for Linux, `PTHREAD_PROCESS_PRIVATE` is passed as the second argument of the `pthread_mutex_init()` function. However, `PTHREAD_PROCESS_PRIVATE` is not a valid pointer to an instance of the `pthread_mutexattr_t` structure. This code does not crash (yet) on Linux, since `PTHREAD_PROCESS_PRIVATE` expands to a numeric value of zero.

According to the [POSIX description of the pthread_mutexattr_setpshared() function](http://pubs.opengroup.org/onlinepubs/007908799/xsh/pthread_mutexattr_setpshared.html), the `PTHREAD_PROCESS_PRIVATE` flag is set by default. It is thus safe to pass `NULL` instead as the second argument to the `pthread_mutex_init()` function to set the default attributes.