### PR TITLE
Avoid incorrect pattern of use of ReentrantLock.tryLock()

### DIFF
--- a/Java/Eta/Core/src/main/java/com/thomsonreuters/upa/transport/RsslSocketChannel.java
+++ b/Java/Eta/Core/src/main/java/com/thomsonreuters/upa/transport/RsslSocketChannel.java
@@ -1211,9 +1211,9 @@ class RsslSocketChannel extends UpaNode implements Channel
         TransportBuffer data = null; // the data returned to the user
         int returnValue;
 
-        try
+        if (_readLock.trylock())
         {
-            if (_readLock.trylock())
+            try
             {
                 // return FAILURE if channel not active
                 if (_state != ChannelState.ACTIVE)
@@ -1340,70 +1340,70 @@ class RsslSocketChannel extends UpaNode implements Channel
                         break;
                 }
             }
-            else
+            catch (CompressorException e)
             {
-                // failed to obtain the lock
-                returnValue = TransportReturnCodes.READ_IN_PROGRESS;
+                _state = ChannelState.CLOSED;
+                returnValue = TransportReturnCodes.FAILURE;
+                error.channel(this);
+                error.errorId(TransportReturnCodes.FAILURE);
+                error.sysError(0);
+                populateErrorDetails(error, TransportReturnCodes.FAILURE, "CompressorException: " + e.getLocalizedMessage());
             }
-        }
-        catch (CompressorException e)
-        {
-            _state = ChannelState.CLOSED;
-            returnValue = TransportReturnCodes.FAILURE;
-            error.channel(this);
-            error.errorId(TransportReturnCodes.FAILURE);
-            error.sysError(0);
-            populateErrorDetails(error, TransportReturnCodes.FAILURE, "CompressorException: " + e.getLocalizedMessage());
-        }
-        catch (Exception e)
-        {
-            if (_providerHelper != null && _providerHelper._wininetControl)
+            catch (Exception e)
             {
-                // should be on original RsslChannel
-                if (RsslHttpSocketChannelProvider.debugPrint)
-                    System.out.println(" Wininet consumer closed the old control socket.");
-
-                // check to see if streaming channel is still there in case of hard killing
-                if (_providerHelper._needCloseOldChannel)
+                if (_providerHelper != null && _providerHelper._wininetControl)
                 {
-                    returnValue = _providerHelper.switchWininetSession(error);
+                    // should be on original RsslChannel
+                    if (RsslHttpSocketChannelProvider.debugPrint)
+                        System.out.println(" Wininet consumer closed the old control socket.");
+
+                    // check to see if streaming channel is still there in case of hard killing
+                    if (_providerHelper._needCloseOldChannel)
+                    {
+                        returnValue = _providerHelper.switchWininetSession(error);
+                    }
+                    else
+                    {
+                        error.channel(this);
+                        error.errorId(TransportReturnCodes.FAILURE);
+                        error.sysError(0);
+                        error.text("Channel closed already...");
+                        _providerHelper.closeStreamingSocket();
+                        returnValue = TransportReturnCodes.FAILURE;
+                    }
+                }
+                else if (_providerHelper != null)
+                {
+                    returnValue = TransportReturnCodes.FAILURE;
+                    if (returnValue == TransportReturnCodes.FAILURE)
+                    {
+                        if (RsslHttpSocketChannelProvider.debugPrint)
+                            System.out.println("Java channel error.......");
+                        error.channel(this);
+                        error.errorId(TransportReturnCodes.FAILURE);
+                        error.sysError(0);
+                        error.text("Java channel error.......");
+                        _needCloseSocket = true;
+                        _providerHelper.closeStreamingSocket();
+                    }
                 }
                 else
                 {
-                    error.channel(this);
-                    error.errorId(TransportReturnCodes.FAILURE);
-                    error.sysError(0);
-                    error.text("Channel closed already...");
-                    _providerHelper.closeStreamingSocket();
-                    returnValue = TransportReturnCodes.FAILURE;
-                }
-            }
-            else if (_providerHelper != null)
-            {
-                returnValue = TransportReturnCodes.FAILURE;
-                if (returnValue == TransportReturnCodes.FAILURE)
-                {
-                    if (RsslHttpSocketChannelProvider.debugPrint)
-                        System.out.println("Java channel error.......");
-                    error.channel(this);
-                    error.errorId(TransportReturnCodes.FAILURE);
-                    error.sysError(0);
-                    error.text("Java channel error.......");
                     _needCloseSocket = true;
-                    _providerHelper.closeStreamingSocket();
+                    _state = ChannelState.CLOSED;
+                    returnValue = TransportReturnCodes.FAILURE;
+                    populateErrorDetails(error, TransportReturnCodes.FAILURE, e.getLocalizedMessage());
                 }
             }
-            else
+            finally
             {
-                _needCloseSocket = true;
-                _state = ChannelState.CLOSED;
-                returnValue = TransportReturnCodes.FAILURE;
-                populateErrorDetails(error, TransportReturnCodes.FAILURE, e.getLocalizedMessage());
+                _readLock.unlock();
             }
         }
-        finally
+        else
         {
-            _readLock.unlock();
+            // failed to obtain the lock
+            returnValue = TransportReturnCodes.READ_IN_PROGRESS;
         }
 
         ((ReadArgsImpl)readArgs).readRetVal(returnValue);


### PR DESCRIPTION
We have a OmmConsumer application using EMA SDK version 3.3.1.0.
We are running in API_DISPATCH mode.
In this mode, there is a reactor dispatch thread and a worker thread.

We occasionally see the following exception:
```
Exception in thread "pool-5-thread-1" java.lang.IllegalMonitorStateException
        at java.util.concurrent.locks.ReentrantLock$Sync.tryRelease(ReentrantLock.java:151)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.release(AbstractQueuedSynchronizer.java:1261)
        at java.util.concurrent.locks.ReentrantLock.unlock(ReentrantLock.java:457)
        at com.thomsonreuters.upa.transport.ReentrantLock.unlock(ReentrantLock.java:28)
        at com.thomsonreuters.upa.transport.RsslHttpSocketChannel.read(RsslHttpSocketChannel.java:1296)
        at com.thomsonreuters.upa.valueadd.reactor.Reactor.performChannelRead(Reactor.java:2242)
        at com.thomsonreuters.upa.valueadd.reactor.Reactor.dispatchChannel(Reactor.java:1909)
        at com.thomsonreuters.upa.valueadd.reactor.ReactorChannel.dispatch(ReactorChannel.java:533)
        at com.thomsonreuters.ema.access.OmmBaseImpl.rsslReactorDispatchLoop(OmmBaseImpl.java:1271)
        at com.thomsonreuters.ema.access.OmmBaseImpl.run(OmmBaseImpl.java:1404)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```
When the exception occurs, the dispatch task has failed, so it is no longer run by its executor and so the application stops processing incoming messages.

We think this is because of an incorrect pattern of use of ReentrantLock.

The dispatch task uses the incorrect locking pattern at RsslHttpSocketChannel.java:1131
One possible cause of the error is that the worker task also accesses the same lock when reconnecting during ping handling, at RsslHttpSocketChannel.java:1563
There may be other lock accesses from non-dispatch threads, we don't know this codebase well.
We do not know for sure that the worker thread reconnect interaction is the cause of the illegal monitor state, but it seems clear that the dispatch task lock usage is incorrect.

The broken pattern is
```
 try
 {
     if (lock.trylock())
     {
 ...
     }
 }
 catch (...)
 {
 ...
 }
 finally
 {
     lock.unlock();
 }
```
An equivalent correct pattern might be
```
 try
 {
     if (lock.trylock())
     {
 	try
         {
 ...
         }
         finally
         {
             lock.unlock();
         }
     }
 }
 catch (...)
 {
 ...
 }
```
For simplicity this commit does not preserve the exact same exception
handling. The code which handles a failure to lock used to be run within
the try-catch block, and isn't any more. However, since the try-catch blocks
seem to be there only to protect the case of successfully locking, this
shouldn't make any difference to the behaviour.

Please let us know what you think.
If this seems OK, let us know and we'll sign the contributor agreement.