### PR TITLE
Allow EmaConfig file to be loaded from a classpath resource

### DIFF
--- a/Java/Ema/Core/src/main/java/com/thomsonreuters/ema/access/ConfigReader.java
+++ b/Java/Ema/Core/src/main/java/com/thomsonreuters/ema/access/ConfigReader.java
@@ -7,6 +7,8 @@
 
 package com.thomsonreuters.ema.access;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -892,7 +894,9 @@ class ConfigReader
 		 *
 		 * if parameter path is empty, attempt to read and parse file EmaConfig.xml in the current working directory.
 		 *
-		 * if parameter path is not empty, read the configuration from path if it is a file or file path/EmaConfig.xml if path is a directory.
+		 * if parameter path is not empty, attempt to read configuration from a classpath resource located at the specified path.
+		 * if no classpath resource exists at the path, attempt to read the configuration from path if it is a file or file path/EmaConfig.xml if path is a directory.
+		 *
 		 * If a configuration cannot be constructed from the given path, throw an OmmInvalidConfigurationException exception
 		 */
 		protected void loadFile(String path)
@@ -900,9 +904,12 @@ class ConfigReader
 			String fileName;	// eventual location of configuration file
 			final String defaultFileName = "EmaConfig.xml";
 
-			if (path == null || path.isEmpty())
+			if (path == null || path.isEmpty()) {
 				fileName = defaultFileName;
-			else {
+			} else if (isClasspathResource(path)) {
+				fileName = path;
+				errorTracker().append( "detected configuration file [" ).append( fileName ).append( "] in classpath").create(Severity.TRACE);
+			} else {
 				File tmp = new File(path);
 				if(!tmp.exists()) {
 					String errorMsg = String.format("configuration path [%s] does not exist; working directory was [%s]", path,
@@ -939,12 +946,12 @@ class ConfigReader
 							path, System.getProperty("user.dir"));
 					throw _parent.oommICExcept().message(errorMsg);
 				}
+
+				// at this point, we have a fileName, a path with that name exists, and that path is a file
+				errorTracker().append( "reading configuration file [" ).append( fileName ).append( "]; working directory is [" )
+						.append( System.getProperty("user.dir") ).append( "]" ).create(Severity.TRACE);
 			}
 
-			// at this point, we have a fileName, a path with that name exists, and that path is a file
-			errorTracker().append( "reading configuration file [" ).append( fileName ).append( "]; working directory is [" )
-			.append( System.getProperty("user.dir") ).append( "]" ).create(Severity.TRACE);
-			
 			XMLConfiguration config = null;
 			try 
 			{
@@ -994,6 +1001,15 @@ class ConfigReader
 
 			// debugging
 			// xmlRoot.dump(0);
+		}
+
+		boolean isClasspathResource(String resourceName)
+		{
+			try (InputStream in = getClass().getClassLoader().getResourceAsStream(resourceName)) {
+				return in != null;
+			} catch (IOException e) {
+				return false;
+			}
 		}
 
 		void verifyAndGetDefaultConsumer()

--- a/Java/Ema/Core/src/test/java/com/thomsonreuters/ema/unittest/EmaFileConfigJunitTests.java
+++ b/Java/Ema/Core/src/test/java/com/thomsonreuters/ema/unittest/EmaFileConfigJunitTests.java
@@ -349,7 +349,305 @@ public class EmaFileConfigJunitTests extends TestCase
 		TestUtilities.checkResult("Port == usr14002", chanPort.contentEquals("usr14002"));
 	
 	}
-	
+
+	public void testLoadCfgFromFileInClasspath()
+	{
+		TestUtilities.printTestHead("testLoadCfgFromFileInClasspath","Test loading configuration from a config file located within the classpath");
+
+		String EmaConfigFileLocation = "com/thomsonreuters/ema/unittest/EmaFileConfigTests/EmaConfigTest.xml";
+
+		OmmConsumerConfig testConfig = EmaFactory.createOmmConsumerConfig(EmaConfigFileLocation);
+
+		// Check default consumer name (Conusmer_2) and associated values
+		System.out.println("Retrieving DefaultConsumer configuration values: (DefaultConsumer value=Consumer_2) ");
+
+		String defaultConsName = JUnitTestConnect.configGetConsumerName(testConfig);
+		TestUtilities.checkResult("DefaultConsumer value != null", defaultConsName != null);
+		TestUtilities.checkResult("DefaultConsumer value == Consumer_2", defaultConsName.contentEquals("Consumer_2") );
+		String ConsChannelVal = JUnitTestConnect.configGetChannelName(testConfig, defaultConsName);
+		TestUtilities.checkResult("Channel value != null", ConsChannelVal != null);
+		TestUtilities.checkResult("Channel value == Channel_2", ConsChannelVal.contentEquals("Channel_2") );
+		String ConsDictionary = JUnitTestConnect.configGetDictionaryName(testConfig, defaultConsName);
+		TestUtilities.checkResult("Dictionary != null", ConsDictionary != null);
+		TestUtilities.checkResult("Dictionary value == Dictionary_2", ConsDictionary.contentEquals("Dictionary_2") );
+		int intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.ItemCountHint);
+		TestUtilities.checkResult("ItemCountHint value == 500000", intLongValue == 500000 );
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.ServiceCountHint);
+		TestUtilities.checkResult("ServiceCountHint value == 655", intLongValue == 655 );
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.ConsumerObeyOpenWindow);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.ConsumerPostAckTimeout);
+		TestUtilities.checkResult("PostAckTimeout value == 7000", intLongValue == 7000 );
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.RequestTimeout);
+		TestUtilities.checkResult("RequestTimeout value == 8000", intLongValue == 8000 );
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.ConsumerMaxOutstandingPosts);
+		TestUtilities.checkResult("MaxOutstandingPosts value == 90000", intLongValue == 90000 );
+		int intValue = JUnitTestConnect.configGetIntValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.DispatchTimeoutApiThread);
+		TestUtilities.checkResult("DispatchTimeoutApiThread value == 90", intValue == 90 );
+
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.MaxDispatchCountApiThread);
+		TestUtilities.checkResult("MaxDispatchCountApiThread value == 400", intLongValue == 400 );
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.MaxDispatchCountUserThread);
+		TestUtilities.checkResult("MaxDispatchCountUserThread value == 5", intLongValue == 5 );
+
+		intValue = JUnitTestConnect.configGetIntValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.ReconnectAttemptLimit);
+		TestUtilities.checkResult("ReconnectAttemptLimit == 5", intValue == 10);
+		intValue = JUnitTestConnect.configGetIntValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.ReconnectMinDelay);
+		TestUtilities.checkResult("ReconnectMinDelay == 330", intValue == 123);
+		intValue = JUnitTestConnect.configGetIntValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.ReconnectMaxDelay);
+		TestUtilities.checkResult("ReconnectMaxDelay == 450", intValue == 456);
+		boolean boolValue = JUnitTestConnect.configGetBooleanValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.XmlTraceToStdout);
+		TestUtilities.checkResult("XmlTraceToStdout == 0", boolValue == false);
+		boolValue = JUnitTestConnect.configGetBooleanValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.ConsumerMsgKeyInUpdates);
+		TestUtilities.checkResult("MsgKeyInUpdates == 1", boolValue == true);
+
+		intValue = JUnitTestConnect.configGetIntLongValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.RestRequestTimeout);
+		TestUtilities.checkResult("RestRequestTimeOut == 60000", intValue == 60000);
+		intValue = JUnitTestConnect.configGetIntValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.ReissueTokenAttemptLimit);
+		TestUtilities.checkResult("ReissueTokenAttemptLimit == 5", intValue == 5);
+		intValue = JUnitTestConnect.configGetIntValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.ReissueTokenAttemptInterval);
+		TestUtilities.checkResult("ReissueTokenAttemptInterval == 7000", intValue == 7000);
+		double doubleValue = JUnitTestConnect.configDoubleIntValue(testConfig, defaultConsName, JUnitTestConnect.ConfigGroupTypeConsumer, JUnitTestConnect.TokenReissueRatio);
+		TestUtilities.checkResult("TokenReissueRatio == 0.5", doubleValue == 0.5);
+
+		// Check values of Consumer_1
+		System.out.println("\nRetrieving Consumer_1 configuration values ");
+
+		ConsChannelVal = JUnitTestConnect.configGetChannelName(testConfig, "Consumer_1");
+		TestUtilities.checkResult("Channel value != null", ConsChannelVal != null);
+		TestUtilities.checkResult("Channel value == Channel_1", ConsChannelVal.contentEquals("Channel_1") );
+		ConsDictionary = JUnitTestConnect.configGetDictionaryName(testConfig, "Consumer_1");
+		TestUtilities.checkResult("Dictionary != null", ConsDictionary != null);
+		TestUtilities.checkResult("Dictionary value == Dictionary_1", ConsDictionary.contentEquals("Dictionary_1") );
+
+		// Check values of Consumer_3
+		System.out.println("\nRetrieving Consumer_3 configuration values ");
+
+		ConsChannelVal = JUnitTestConnect.configGetChannelName(testConfig, "Consumer_3");
+		TestUtilities.checkResult("Channel value != null", ConsChannelVal != null);
+		TestUtilities.checkResult("Channel value == Channel_1", ConsChannelVal.contentEquals("Channel_1") );
+		ConsDictionary = JUnitTestConnect.configGetDictionaryName(testConfig, "Consumer_3");
+		TestUtilities.checkResult("Dictionary != null", ConsDictionary != null);
+		TestUtilities.checkResult("Dictionary value == Dictionary_1", ConsDictionary.contentEquals("Dictionary_1") );
+
+		// Check values of Consumer_4
+		System.out.println("\nRetrieving Consumer_4 configuration values ");
+
+		ConsChannelVal =  JUnitTestConnect.configGetChannelName(testConfig, "Consumer_4");
+		TestUtilities.checkResult("ChannelSet value != null", ConsChannelVal != null);
+		TestUtilities.checkResult("ChannelSet value == Channel_4, Channel_5", ConsChannelVal.contentEquals("Channel_4,Channel_5") );
+		ConsDictionary = JUnitTestConnect.configGetDictionaryName(testConfig, "Consumer_4");
+		TestUtilities.checkResult("Dictionary != null", ConsDictionary != null);
+		TestUtilities.checkResult("Dictionary value == Dictionary_1", ConsDictionary.contentEquals("Dictionary_1") );
+
+		// Check values of Consumer_5
+		System.out.println("\nRetrieving Consumer_5 configuration values ");
+
+		ConsChannelVal = JUnitTestConnect.configGetChannelName(testConfig, "Consumer_5");
+		TestUtilities.checkResult("Channel value != null", ConsChannelVal != null);
+		TestUtilities.checkResult("Channel value == Channel_3", ConsChannelVal.contentEquals("Channel_3") );
+		ConsDictionary = JUnitTestConnect.configGetDictionaryName(testConfig, "Consumer_5");
+		TestUtilities.checkResult("Dictionary != null", ConsDictionary != null);
+		TestUtilities.checkResult("Dictionary value == Dictionary_2", ConsDictionary.contentEquals("Dictionary_2") );
+
+		// Check values of Consumer_7
+		System.out.println("\nRetrieving Consumer_7 configuration values ");
+
+		ConsChannelVal = JUnitTestConnect.configGetChannelName(testConfig, "Consumer_7");
+		TestUtilities.checkResult("Channel value != null", ConsChannelVal != null);
+		TestUtilities.checkResult("Channel value == Channel_6", ConsChannelVal.contentEquals("Channel_6") );
+		ConsDictionary = JUnitTestConnect.configGetDictionaryName(testConfig, "Consumer_7");
+		TestUtilities.checkResult("Dictionary != null", ConsDictionary != null);
+		TestUtilities.checkResult("Dictionary value == Dictionary_2", ConsDictionary.contentEquals("Dictionary_2") );
+
+		// Check Channel configuration:
+		// Check Channel_1 configuration.
+		ConsChannelVal = "Channel_1";
+		System.out.println("\nRetrieving Channel_1 configuration values ");
+		int channelConnType = JUnitTestConnect.configGetChannelType(testConfig, ConsChannelVal);
+		TestUtilities.checkResult("channelConnType == ChannelType::RSSL_SOCKET", channelConnType == ChannelTypeSocket);
+
+		intValue = JUnitTestConnect.configGetIntValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.CompressionType);
+		TestUtilities.checkResult("CompressionType == CompressionType::None", intValue == CompressionTypeNone);
+
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.GuaranteedOutputBuffers);
+		TestUtilities.checkResult("GuaranteedOutputBuffers == 5000", intLongValue == 5000);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.NumInputBuffers);
+		TestUtilities.checkResult("NumInputBuffers == 7000", intLongValue == 7000);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.SysRecvBufSize);
+		TestUtilities.checkResult("SysRecvBufSize == 125236", intLongValue == 125236);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.SysSendBufSize);
+		TestUtilities.checkResult("SysSendBufSize == 569823", intLongValue == 569823);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.HighWaterMark);
+		TestUtilities.checkResult("HighWaterMark == 3000", intLongValue == 3000);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.CompressionThreshold);
+		TestUtilities.checkResult("CompressionThreshold == 2048", intLongValue == 2048);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ConnectionPingTimeout);
+		TestUtilities.checkResult("ConnectionPingTimeout == 30000", intLongValue == 30000);
+		boolValue = JUnitTestConnect.configGetBooleanValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.TcpNodelay);
+		TestUtilities.checkResult("TcpNodelay == 1", boolValue == true);
+		boolValue = JUnitTestConnect.configGetBooleanValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.DirectWrite);
+		TestUtilities.checkResult("DirectWrite == 1", boolValue == true);
+		String chanHost = JUnitTestConnect.configGetChanHost(testConfig, ConsChannelVal);
+		TestUtilities.checkResult("Host == 0.0.0.1", chanHost.contentEquals("0.0.0.1"));
+		String chanPort = JUnitTestConnect.configGetChanPort(testConfig, ConsChannelVal);
+		TestUtilities.checkResult("Port == 19001", chanPort.contentEquals("19001"));
+
+		// Check Channel_2 configuration.
+		ConsChannelVal = "Channel_2";
+		System.out.println("\nRetrieving Channel_2 configuration values ");
+		channelConnType = JUnitTestConnect.configGetChannelType(testConfig, ConsChannelVal);
+		//change to Socket connection due to non-support conn type.
+		//TestUtilities.checkResult("channelConnType == ChannelType::RSSL_ENCRYPTED", channelConnType == ChannelTypeEncrypted);
+		TestUtilities.checkResult("channelConnType == ChannelType::RSSL_SOCKET", channelConnType == ChannelTypeSocket);
+		String strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.InterfaceName);
+		TestUtilities.checkResult("InterfaceName == localhost4file", strValue.contentEquals("localhost4file"));
+		intValue = JUnitTestConnect.configGetIntValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.CompressionType);
+		TestUtilities.checkResult("CompressionType == CompressionType::Zlib", intValue == CompressionTypeZLib);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.GuaranteedOutputBuffers);
+		TestUtilities.checkResult("GuaranteedOutputBuffers == 6000", intLongValue == 6000);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.NumInputBuffers);
+		TestUtilities.checkResult("NumInputBuffers == 9000", intLongValue == 9000);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.SysRecvBufSize);
+		TestUtilities.checkResult("SysRecvBufSize == 23656", intLongValue == 23656);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.SysSendBufSize);
+		TestUtilities.checkResult("SysSendBufSize == 63656", intLongValue == 63656);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.CompressionThreshold);
+		TestUtilities.checkResult("CompressionThreshold == 4096", intLongValue == 4096);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ConnectionPingTimeout);
+		TestUtilities.checkResult("ConnectionPingTimeout == 55555", intLongValue == 55555);
+		chanHost = JUnitTestConnect.configGetChanHost(testConfig, ConsChannelVal);
+		TestUtilities.checkResult("Host == 0.0.0.2", chanHost.contentEquals("0.0.0.2"));
+		chanPort = JUnitTestConnect.configGetChanPort(testConfig, ConsChannelVal);
+		TestUtilities.checkResult("Port == 15008", chanPort.contentEquals("15008"));
+		boolValue = JUnitTestConnect.configGetBooleanValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.TcpNodelay);
+		TestUtilities.checkResult("TcpNodelay == 0", boolValue == false);
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ObjectName);
+		TestUtilities.checkResult("ObjectName == HttpObjectName", strValue.contentEquals("HttpObjectName"));
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelInitTimeout);
+		TestUtilities.checkResult("InitializationTimeout == 55", intLongValue == 55);
+
+		// Check Channel_3 configuration.
+		ConsChannelVal = "Channel_3";
+		System.out.println("\nRetrieving Channel_3 configuration values ");
+		channelConnType = JUnitTestConnect.configGetChannelType(testConfig, ConsChannelVal);
+		TestUtilities.checkResult("channelConnType == ChannelType::RSSL_SOCKET", channelConnType == ChannelTypeSocket);
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.InterfaceName);
+		TestUtilities.checkResult("InterfaceName != null", strValue != null);
+		TestUtilities.checkResult("InterfaceName == localhost", strValue.contentEquals("localhost"));
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelUnicastPort);
+		TestUtilities.checkResult("Unicastport != null", strValue != null);
+		TestUtilities.checkResult("UnicastPort == 40102", strValue.contentEquals("40102"));
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelRecvAddress);
+		TestUtilities.checkResult("RecvAddress != null", strValue != null);
+		TestUtilities.checkResult("RecvAddress == 0.0.0.3", strValue.contentEquals("0.0.0.3"));
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelRecvPort);
+		TestUtilities.checkResult("RecvPort != null", strValue != null);
+		TestUtilities.checkResult("RecvPort == 15008", strValue.contentEquals("15008"));
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelSendAddress);
+		TestUtilities.checkResult("SendAddress != null", strValue != null);
+		TestUtilities.checkResult("SendAddress == 0.0.0.4", strValue.contentEquals("0.0.0.4"));
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelSendPort);
+		TestUtilities.checkResult("SendPort != null", strValue != null);
+		TestUtilities.checkResult("SendPort == 15007", strValue.contentEquals("15007"));
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelHsmInterface);
+		TestUtilities.checkResult("HsmInterface != null", strValue != null);
+		TestUtilities.checkResult("HsmInterface == 0.0.0.5", strValue.contentEquals("0.0.0.5"));
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelHsmMultAddress);
+		TestUtilities.checkResult("HsmMultAddress != null", strValue != null);
+		TestUtilities.checkResult("HsmMultAddress == 0.0.0.6", strValue.contentEquals("0.0.0.6"));
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelHsmPort);
+		TestUtilities.checkResult("HsmPort != null", strValue != null);
+		TestUtilities.checkResult("HsmPort == 15005", strValue.contentEquals("15005"));
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChanneltcpControlPort);
+		TestUtilities.checkResult("TcpControlPort != null", strValue != null);
+		TestUtilities.checkResult("TcpControlPort == 15018", strValue.contentEquals("15018"));
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelPacketTTL);
+		TestUtilities.checkResult("PacketTTL == 10", intLongValue == 10);
+		boolValue = JUnitTestConnect.configGetBooleanValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelDisconnectOnGap);
+		TestUtilities.checkResult("DisconnectOnGap == 1", boolValue == true);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.Channelndata);
+		TestUtilities.checkResult("ndata == 8", intLongValue == 8);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.Channelnmissing);
+		TestUtilities.checkResult("nmissing == 130", intLongValue == 130);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.Channelnrreq);
+		TestUtilities.checkResult("nrreq == 5", intLongValue == 5);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.Channeltdata);
+		TestUtilities.checkResult("tdata == 0", intLongValue == 0);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.Channeltrreq);
+		TestUtilities.checkResult("trreq == 5", intLongValue == 5);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelpktPoolLimitHigh);
+		TestUtilities.checkResult("pktPoolLimitHigh == 190500", intLongValue == 190500);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelpktPoolLimitLow);
+		TestUtilities.checkResult("pktPoolLimitLow == 180500", intLongValue == 180500);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.Channeltwait);
+		TestUtilities.checkResult("twait == 4", intLongValue == 4);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.Channeltbchold);
+		TestUtilities.checkResult("tbchold == 4", intLongValue == 4);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.Channeltpphold);
+		TestUtilities.checkResult("tpphold == 4", intLongValue == 4);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChanneluserQLimit);
+		TestUtilities.checkResult("userQLimit == 65535", intLongValue == 65535);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ChannelHsmInterval);
+		TestUtilities.checkResult("HsmInterval == 10", intLongValue == 10);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.GuaranteedOutputBuffers);
+		TestUtilities.checkResult("GuaranteedOutputBuffers == 5500", intLongValue == 5500);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.NumInputBuffers);
+		TestUtilities.checkResult("NumInputBuffers == 9500", intLongValue == 9500);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.SysRecvBufSize);
+		TestUtilities.checkResult("SysRecvBufSize == 125000", intLongValue == 125000);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.SysSendBufSize);
+		TestUtilities.checkResult("SysSendBufSize == 550000", intLongValue == 550000);
+		intLongValue = JUnitTestConnect.configGetIntLongValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ConnectionPingTimeout);
+		TestUtilities.checkResult("ConnectionPingTimeout == 3555", intLongValue == 3555);
+
+		// Check Channel_6 configuration.
+		ConsChannelVal = "Channel_6";
+		System.out.println("\nRetrieving Channel_6 configuration values ");
+		channelConnType = JUnitTestConnect.configGetChannelType(testConfig, ConsChannelVal);
+		TestUtilities.checkResult("channelConnType == ChannelType::RSSL_ENCRYPTED", channelConnType == ChannelTypeEncrypted);
+
+		chanHost = JUnitTestConnect.configGetChanHost(testConfig, ConsChannelVal);
+		TestUtilities.checkResult("Host == 122.1.1.200", chanHost.contentEquals("122.1.1.200"));
+		chanPort = JUnitTestConnect.configGetChanPort(testConfig, ConsChannelVal);
+		TestUtilities.checkResult("Port == 14010", chanPort.contentEquals("14010"));
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.ObjectName);
+		TestUtilities.checkResult("ObjectName == EncrpyptedObjectName2", strValue.contentEquals("EncrpyptedObjectName2"));
+		strValue = JUnitTestConnect.configGetStringValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.Location);
+		TestUtilities.checkResult("Location == us-east", strValue.contentEquals("us-east"));
+		boolValue = JUnitTestConnect.configGetBooleanValue(testConfig, ConsChannelVal, JUnitTestConnect.ConfigGroupTypeChannel, JUnitTestConnect.EnableSessionMgnt);
+		TestUtilities.checkResult("EnableSessionManagement == 1", boolValue == true);
+
+		// Check Dictionary_1 configuration.
+		ConsDictionary = "Dictionary_1";
+		System.out.println("\nRetrieving Dictionary_1 configuration values ");
+		intValue = JUnitTestConnect.configGetIntValue(testConfig, ConsDictionary, JUnitTestConnect.ConfigGroupTypeDictionary, JUnitTestConnect.DictionaryType);
+		TestUtilities.checkResult("DictionaryType == DictionaryType::ChannelDictionary (0)", intValue == 0);
+
+		// Check Dictionary_2 configuration.
+		ConsDictionary = "Dictionary_2";
+		System.out.println("\nRetrieving Dictionary_2 configuration values ");
+		intValue = JUnitTestConnect.configGetIntValue(testConfig, ConsDictionary, JUnitTestConnect.ConfigGroupTypeDictionary, JUnitTestConnect.DictionaryType);
+		TestUtilities.checkResult("DictionaryType == DictionaryType::FileDictionary (1)", intValue == 1);
+		strValue =  JUnitTestConnect.configGetStringValue(testConfig, ConsDictionary, JUnitTestConnect.ConfigGroupTypeDictionary, JUnitTestConnect.DictionaryRDMFieldDictFileName);
+		TestUtilities.checkResult("RdmFieldDictionaryFileName == ./RDMFieldDictionary", strValue.contentEquals("./RDMFieldDictionary"));
+		strValue =   JUnitTestConnect.configGetStringValue(testConfig, ConsDictionary, JUnitTestConnect.ConfigGroupTypeDictionary, JUnitTestConnect.DictionaryEnumTypeDefFileName);
+		TestUtilities.checkResult("RdmFieldDictionaryFileName == ./enumtype.def", strValue.contentEquals("./enumtype.def"));
+
+		// Check user specified host and port.
+		ConsChannelVal = "Channel_2";
+		System.out.println("\nCheck user specified host and port ");
+		String tmpString = "usrLocalhost:usr14002";
+		testConfig.host(tmpString);
+		channelConnType = JUnitTestConnect.configGetChannelType(testConfig, ConsChannelVal);
+		TestUtilities.checkResult("channelConnType == ChannelType::RSSL_SOCKET", channelConnType == ChannelTypeSocket);
+		chanHost = JUnitTestConnect.configGetChanHost(testConfig, ConsChannelVal);
+		TestUtilities.checkResult("Host == usrLocalhost", chanHost.contentEquals("usrLocalhost"));
+		chanPort = JUnitTestConnect.configGetChanPort(testConfig, ConsChannelVal);
+		TestUtilities.checkResult("Port == usr14002", chanPort.contentEquals("usr14002"));
+
+	}
+
+
 	public void testLoadFromFileCfgChannelSet()
 	{
 		String consumerName = "";


### PR DESCRIPTION
Please consider this fix for review and inclusion in the next release.

This addresses https://github.com/Refinitiv/Elektron-SDK/issues/69

The underlying apache commons library reading the config file actually supports paths to resources in the classpath, so this fix is simply passing the path to it if it determines the file exists within the classpath. 
I have tried to minimize code changes in this area.

Thank you,
Matt