### PR TITLE
Catch polymorphic type by reference, not by value (take 2).

### DIFF
--- a/Cpp-C/Ema/Src/Access/Impl/EmaBuffer.cpp
+++ b/Cpp-C/Ema/Src/Access/Impl/EmaBuffer.cpp
@@ -335,7 +335,7 @@ const char* EmaBuffer::asRawHexString() const
 		try {
 			_pCastingOperatorContext = new CastingOperatorContext;
 		}
-		catch (std::bad_alloc)
+		catch (std::bad_alloc&)
 		{
 			const char* temp = "Failed to allocate memory in EmaBuffer::operator const char* () const.";
 			throwMeeException(temp);

--- a/Cpp-C/Ema/Src/Access/Impl/OmmConsumerImpl.cpp
+++ b/Cpp-C/Ema/Src/Access/Impl/OmmConsumerImpl.cpp
@@ -158,7 +158,7 @@ void OmmConsumerImpl::loadDictionary()
 		try {
 			pWatcher = new TimeOut(*this, timeOutLengthInMicroSeconds, &OmmBaseImpl::terminateIf, reinterpret_cast<void*>(this), true);
 		}
-		catch (std::bad_alloc) {
+		catch (std::bad_alloc&) {
 			throwMeeException("Failed to allocate memory in OmmConsumerImpl::loadDictionary().");
 			return;
 		}

--- a/Cpp-C/Ema/Src/Access/Impl/OmmServerBaseImpl.cpp
+++ b/Cpp-C/Ema/Src/Access/Impl/OmmServerBaseImpl.cpp
@@ -438,7 +438,7 @@ ServerConfig* OmmServerBaseImpl::readServerConfig( EmaConfigServerImpl* pConfigS
 					socketServerConfig = new SocketServerConfig(_activeServerConfig.defaultServiceName());
 					newServerConfig = socketServerConfig;
 				}
-				catch (std::bad_alloc) {}
+				catch (std::bad_alloc&) {}
 
 				if (!socketServerConfig)
 				{

--- a/Cpp-C/Ema/Src/Access/Impl/ServiceEndpointDiscovery.cpp
+++ b/Cpp-C/Ema/Src/Access/Impl/ServiceEndpointDiscovery.cpp
@@ -21,7 +21,7 @@ ServiceEndpointDiscovery::ServiceEndpointDiscovery(const EmaString& tokenService
 	{
 		_pImpl = new ServiceEndpointDiscoveryImpl(this, tokenServiceURL, serviceDiscoveryURL);
 	}
-	catch (std::bad_alloc) {}
+	catch (std::bad_alloc&) {}
 
 	if (!_pImpl)
 		throwMeeException("Failed to allocate memory for ServiceEndpointDiscoveryImpl in ServiceEndpointDiscovery( const EmaString&, const EmaString& ).");

--- a/Cpp-C/Ema/Src/Access/Impl/ServiceEndpointDiscoveryInfo.cpp
+++ b/Cpp-C/Ema/Src/Access/Impl/ServiceEndpointDiscoveryInfo.cpp
@@ -24,7 +24,7 @@ _toString(0,256)
 		_pDataFormatList = new EmaVector<EmaString>(2);
 		_pLocationList = new EmaVector<EmaString>(2);
 	}
-	catch (std::bad_alloc)
+	catch (std::bad_alloc&)
 	{
 		// it's safe to delete nullptr
 		delete _pDataFormatList;

--- a/Cpp-C/Ema/Src/Access/Impl/ServiceEndpointDiscoveryResp.cpp
+++ b/Cpp-C/Ema/Src/Access/Impl/ServiceEndpointDiscoveryResp.cpp
@@ -22,7 +22,7 @@ _toString(0,4096)
 	{
 		_pServiceEndpointDiscoveryInfoList = new EmaVector<ServiceEndpointDiscoveryInfo>(16);
 	}
-	catch (std::bad_alloc) {}
+	catch (std::bad_alloc&) {}
 
 	if (!_pServiceEndpointDiscoveryInfoList)
 		throwMeeException("Failed to allocate memory for EmaVector<ServiceEndpointDiscoveryInfo> in ServiceEndpointDiscoveryResp().");


### PR DESCRIPTION
Catching by reference means no copy is made. Spotted by GCC's -Wcatch-value.  This patch fixes new instances of catching by value that were introduced since the last patch.