### PR TITLE
Make destructor virtual because of polymorphic class object deletion.

### DIFF
--- a/Cpp-C/Eta/Impl/Converter/Include/rtr/rwfToJsonBase.h
+++ b/Cpp-C/Eta/Impl/Converter/Include/rtr/rwfToJsonBase.h
@@ -159,7 +159,7 @@ public:
 	rwfToJsonBase(int bufSize, int maxPrequel, RsslUInt16 convFlags = 0, int numTokens = DEFAULT_NUM_TOKENS, int incSize = DEFAULT_NUM_TOKENS);
 
 	// Destructor
-	~rwfToJsonBase();
+	virtual ~rwfToJsonBase();
 
 	static void initializeIntToStringTable();
 	static void uninitializeIntToStringTable();


### PR DESCRIPTION
GCC says (-Wdelete-non-virtual-dtor):

  Eta/Impl/Converter/rsslJsonConverter.cpp:102:26: warning: deleting object of polymorphic class type 'rwfToJsonSimple' which has non-virtual destructor might cause undefined behavior
  Eta/Impl/Converter/rsslJsonConverter.cpp:114:26: warning: deleting object of polymorphic class type 'rwfToJsonConverter' which has non-virtual destructor might cause undefined behavior

Resolve this by making the destructor of the base type virtual.