### PR TITLE
Fix memset arguments order

### DIFF
--- a/Cpp-C/Eta/Impl/Reactor/Util/rsslRestClientImpl.c
+++ b/Cpp-C/Eta/Impl/Reactor/Util/rsslRestClientImpl.c
@@ -3352,7 +3352,7 @@ RsslRet rsslGenerateSignedJWT(RsslBuffer* JWK, RsslBuffer* aud, RsslBuffer* out,
 				(*(cryptoFuncs->bn_free))(rsa.dmq1);
 				(*(cryptoFuncs->bn_clear))(rsa.iqmp);
 				(*(cryptoFuncs->bn_free))(rsa.iqmp);
-			memset(&rsa, sizeof(OPENSSL_10_rsa), 0);
+			memset(&rsa, 0, sizeof(OPENSSL_10_rsa));
 
 			JWT_10_RSA_Failure:
 			if(privateKeyFailure == RSSL_TRUE)
@@ -3399,7 +3399,7 @@ RsslRet rsslGenerateSignedJWT(RsslBuffer* JWK, RsslBuffer* aud, RsslBuffer* out,
 					(*(cryptoFuncs->bn_clear))(rsa.iqmp);
 					(*(cryptoFuncs->bn_free))(rsa.iqmp);
 				}
-				memset(&rsa, sizeof(OPENSSL_10_rsa), 0);
+				memset(&rsa, 0, sizeof(OPENSSL_10_rsa));
 				cJSON_Delete(root);
 
 				return RSSL_RET_FAILURE;

--- a/Cpp-C/Eta/TestTools/QATools/etareactor-curlparams-001/rsslRestClientImpl.c
+++ b/Cpp-C/Eta/TestTools/QATools/etareactor-curlparams-001/rsslRestClientImpl.c
@@ -3357,7 +3357,7 @@ RsslRet rsslGenerateSignedJWT(RsslBuffer* JWK, RsslBuffer* aud, RsslBuffer* out,
 				(*(cryptoFuncs->bn_free))(rsa.dmq1);
 				(*(cryptoFuncs->bn_clear))(rsa.iqmp);
 				(*(cryptoFuncs->bn_free))(rsa.iqmp);
-			memset(&rsa, sizeof(OPENSSL_10_rsa), 0);
+			memset(&rsa, 0, sizeof(OPENSSL_10_rsa));
 
 			JWT_10_RSA_Failure:
 			if(privateKeyFailure == RSSL_TRUE)
@@ -3404,7 +3404,7 @@ RsslRet rsslGenerateSignedJWT(RsslBuffer* JWK, RsslBuffer* aud, RsslBuffer* out,
 					(*(cryptoFuncs->bn_clear))(rsa.iqmp);
 					(*(cryptoFuncs->bn_free))(rsa.iqmp);
 				}
-				memset(&rsa, sizeof(OPENSSL_10_rsa), 0);
+				memset(&rsa, 0, sizeof(OPENSSL_10_rsa));
 				cJSON_Delete(root);
 
 				return RSSL_RET_FAILURE;


### PR DESCRIPTION
`memset` expects following arguments

`void * memset ( void * ptr, int value, size_t num );`

Fixed memset calls where order of arguments was incorrect.