### PR TITLE
Remove trailing spaces from compiler options

### DIFF
--- a/CMake/rtsdkAdditionalCompilerOptions.cmake
+++ b/CMake/rtsdkAdditionalCompilerOptions.cmake
@@ -8,7 +8,7 @@
 
 if(CMAKE_HOST_WIN32)
 	if(NOT BUILD_ETA_JWT)
-		set(_jwtBuildFlags "/D NO_ETA_JWT_BUILD ")
+		set(_jwtBuildFlags "/D NO_ETA_JWT_BUILD")
 		
 		set(_rtsdk_flags ${RTSDK_EXTRA_FLAGS} ${_jwtBuildFlags})
 		set(RTSDK_EXTRA_FLAGS "${_rtsdk_flags}" CACHE STRING "Internal RTSDK build flags" FORCE)
@@ -16,7 +16,7 @@ if(CMAKE_HOST_WIN32)
 	endif()
 	
 	if(NOT BUILD_ETA_CPU_BIND)
-		set(_cpuBindFlags "/D NO_ETA_CPU_BIND ")
+		set(_cpuBindFlags "/D NO_ETA_CPU_BIND")
 		
 		set(_rtsdk_flags ${RTSDK_EXTRA_FLAGS} ${_cpuBindFlags})
 		set(RTSDK_EXTRA_FLAGS "${_rtsdk_flags}" CACHE STRING "Internal RTSDK build flags" FORCE)
@@ -24,7 +24,7 @@ if(CMAKE_HOST_WIN32)
 	endif()
 else()
 	if(NOT BUILD_ETA_JWT)
-		set(_jwtBuildFlags "-DNO_ETA_JWT_BUILD ")
+		set(_jwtBuildFlags "-DNO_ETA_JWT_BUILD")
 		
 		set(_rtsdk_flags ${RTSDK_EXTRA_FLAGS} ${_jwtBuildFlags})
 		set(RTSDK_EXTRA_FLAGS "${_rtsdk_flags}" CACHE STRING "Internal RTSDK build flags" FORCE)
@@ -32,7 +32,7 @@ else()
 	endif()
 	
 	if(NOT BUILD_ETA_CPU_BIND)
-		set(_cpuBindFlags "-DNO_ETA_CPU_BIND ")
+		set(_cpuBindFlags "-DNO_ETA_CPU_BIND")
 		
 		set(_rtsdk_flags ${RTSDK_EXTRA_FLAGS} ${_cpuBindFlags})
 		set(RTSDK_EXTRA_FLAGS "${_rtsdk_flags}" CACHE STRING "Internal RTSDK build flags" FORCE)


### PR DESCRIPTION
When compiling with BUILD_ETA_JWT and BUILD_ETA_CPU_BIND disabled, the additional compiler flags have trailing spaces, which are rejected by some compilers.

This change removes the trailing spaces. Separation between arguments is maintained by the space between ${RTSDK_EXTRA_FLAGS} and ${_jwtBuildFlags}.